### PR TITLE
fix(nss): CVE-2026-6766, CVE-2026-6767

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,12 @@
 nss (2:3.105-2deepin2) unstable; urgency=medium
 
-  * Document CVE-2026-6766, CVE-2026-6767: affect NSS, upstream not yet disclosed
+  * Fix CVE-2026-6766: integer underflow in tls13_AEAD when ciphertext is
+    shorter than tag (Bug 2023207)
+  * Fix CVE-2026-6767: permittedSubtrees wildcard matching bypass
+    (Bug 2023209)
   * CVE-2026-2959: no public information available
 
- -- deepin-ci-robot <packages@deepin.org>  Thu, 04 Jun 2026 09:00:00 +0800
+ -- deepin-ci-robot <packages@deepin.org>  Fri, 26 Jun 2026 13:24:00 +0800
 
 nss (2:3.105-2deepin1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nss (2:3.105-2deepin2) unstable; urgency=medium
+
+  * Document CVE-2026-6766, CVE-2026-6767: affect NSS, upstream not yet disclosed
+  * CVE-2026-2959: no public information available
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 04 Jun 2026 09:00:00 +0800
+
 nss (2:3.105-2deepin1) unstable; urgency=medium
 
   * fix CVE-2026-2781 

--- a/debian/patches/CVE-2026-6766-6767.patch
+++ b/debian/patches/CVE-2026-6766-6767.patch
@@ -1,0 +1,6 @@
+Description: CVE-2026-6766 and CVE-2026-6767 affect NSS
+ These CVEs affect NSS but upstream (Mozilla) has not yet published
+ security advisories or fix commits. Debian sid fix is in NSS 3.124-1.
+ Once Mozilla publishes the fix details, this needs to be backported.
+Origin: not-yet-available
+Last-Update: 2026-06-04

--- a/debian/patches/CVE-2026-6766-6767.patch
+++ b/debian/patches/CVE-2026-6766-6767.patch
@@ -1,6 +1,0 @@
-Description: CVE-2026-6766 and CVE-2026-6767 affect NSS
- These CVEs affect NSS but upstream (Mozilla) has not yet published
- security advisories or fix commits. Debian sid fix is in NSS 3.124-1.
- Once Mozilla publishes the fix details, this needs to be backported.
-Origin: not-yet-available
-Last-Update: 2026-06-04

--- a/debian/patches/CVE-2026-6766.patch
+++ b/debian/patches/CVE-2026-6766.patch
@@ -1,0 +1,28 @@
+From: John Schanck <jschanck@mozilla.com>
+Date: Tue, 17 Mar 2026 15:17:37 +0000
+Subject: Bug 2023207 - CVE-2026-6766: Fix integer underflow in tls13_AEAD
+ when ciphertext is shorter than tag
+
+Origin: https://hg.mozilla.org/projects/nss/rev/b009fc00297d
+Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2023207
+
+CVE-2026-6766: Incorrect boundary conditions in the Libraries component in
+NSS. When decrypting with AES-GCM, if the ciphertext length is shorter than
+the authentication tag length, an integer underflow occurs which could lead
+to undefined behavior.
+
+diff --git a/nss/lib/ssl/tls13con.c b/nss/lib/ssl/tls13con.c
+index 27eda69..e74933c 100644
+--- a/nss/lib/ssl/tls13con.c
++++ b/nss/lib/ssl/tls13con.c
+@@ -5148,6 +5148,10 @@ tls13_AEAD(PK11Context *context, PRBool decrypt,
+         PORT_Memcpy(ivOut, ivIn, ivLen);
+     }
+     if (decrypt) {
++        if (inLen < tagLen) {
++            PORT_SetError(SEC_ERROR_INPUT_LEN);
++            return SECFailure;
++        }
+         inLen = inLen - tagLen;
+         tag = (unsigned char *)in + inLen;
+         /* tag is const on decrypt, but returned on encrypt */

--- a/debian/patches/CVE-2026-6767.patch
+++ b/debian/patches/CVE-2026-6767.patch
@@ -1,0 +1,248 @@
+From: Dana Keeler <dkeeler@mozilla.com>
+Date: Wed, 18 Mar 2026 17:22:28 +0000
+Subject: Bug 2023209 - CVE-2026-6767: ensure permittedSubtrees don't match
+ wildcards that could be outside the permitted tree
+
+Origin: https://hg.mozilla.org/projects/nss/rev/c25593a09fd4
+Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2023209
+
+CVE-2026-6767: Other issue in the Libraries component in NSS. When checking
+a presented DNSID that includes a wildcard label (e.g. *.example.com) against
+a name constraint in the permittedSubtrees, the matching was too permissive.
+A constraint like "foo.example.com" should not match "*.example.com", because
+in that case the certificate could be valid for "bar.example.com", which does
+not match the name constraint.
+
+diff --git a/nss/gtests/mozpkix_gtest/pkixnames_tests.cpp b/nss/gtests/mozpkix_gtest/pkixnames_tests.cpp
+index e796d43..0c300ee 100644
+--- a/nss/gtests/mozpkix_gtest/pkixnames_tests.cpp
++++ b/nss/gtests/mozpkix_gtest/pkixnames_tests.cpp
+@@ -2132,6 +2132,45 @@ static const NameConstraintParams NAME_CONSTRAINT_PARAMS[] =
+     Result::ERROR_BAD_DER, Result::ERROR_BAD_DER
+   },
+ 
++  // Wildcard SANs have subtle outcomes.
++  { ByteString(), DNSName("*.example.com"),
++    GeneralSubtree(DNSName(".example.com")),
++    Success,
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE
++  },
++  { ByteString(), DNSName("*.example.com"),
++    GeneralSubtree(DNSName("example.com")),
++    Success,
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE
++  },
++  // A certificate with a wildcard SAN entry like `*.example.com` can't be
++  // issued by a CA with a DNSName name constraint entry like `foo.example.com`
++  // in either the permitted or excluded subtrees. If in the permitted subtree,
++  // the certificate would be valid for `bar.example.com`, which would violate
++  // the constraint. If in the excluded subtree, the certificate would be valid
++  // for `foo.example.com`, which would violate the constraint.
++  { ByteString(), DNSName("*.example.com"),
++    GeneralSubtree(DNSName("foo.example.com")),
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE,
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE
++  },
++  { ByteString(), DNSName("*.foo.example.com"),
++    GeneralSubtree(DNSName("example.com")),
++    Success,
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE
++  },
++  { ByteString(), DNSName("*.example.com"),
++    GeneralSubtree(DNSName("foo.example.org")),
++    Result::ERROR_CERT_NOT_IN_NAME_SPACE,
++    Success
++  },
++  // `*invalid.example.com` is an invalid presented DNSID.
++  { ByteString(), DNSName("*invalid.example.com"),
++    GeneralSubtree(DNSName("invalid.example.com")),
++    Result::ERROR_BAD_DER,
++    Result::ERROR_BAD_DER
++  },
++
+   /////////////////////////////////////////////////////////////////////////////
+   // Basic IP Address constraints (non-CN-ID)
+ 
+diff --git a/nss/lib/mozpkix/lib/pkixnames.cpp b/nss/lib/mozpkix/lib/pkixnames.cpp
+index 7f31d5e..a63c27a 100644
+--- a/nss/lib/mozpkix/lib/pkixnames.cpp
++++ b/nss/lib/mozpkix/lib/pkixnames.cpp
+@@ -172,6 +172,12 @@ enum class IDRole
+   NameConstraint = 2,
+ };
+ 
++enum class NameConstraintsSubtrees : uint8_t
++{
++  permittedSubtrees = der::CONSTRUCTED | der::CONTEXT_SPECIFIC | 0,
++  excludedSubtrees  = der::CONSTRUCTED | der::CONTEXT_SPECIFIC | 1
++};
++
+ enum class AllowWildcards { No = 0, Yes = 1 };
+ 
+ // DNSName constraints implicitly allow subdomain matching when there is no
+@@ -184,16 +190,22 @@ enum class AllowDotlessSubdomainMatches { No = 0, Yes = 1 };
+ bool IsValidDNSID(Input hostname, IDRole idRole,
+                   AllowWildcards allowWildcards);
+ 
++// `subtreesType` is relevant only when `referenceDNSIDRole` is
++// `IDRole::NameConstraint`.
+ Result MatchPresentedDNSIDWithReferenceDNSID(
+          Input presentedDNSID,
+          AllowWildcards allowWildcards,
+          AllowDotlessSubdomainMatches allowDotlessSubdomainMatches,
+          IDRole referenceDNSIDRole,
++         /*optional*/ const NameConstraintsSubtrees* subtreesType,
+          Input referenceDNSID,
+          /*out*/ bool& matches);
+ 
++// `subtreesType` is relevant only when `referenceDNSIDRole` is
++// `IDRole::NameConstraint`.
+ Result MatchPresentedRFC822NameWithReferenceRFC822Name(
+          Input presentedRFC822Name, IDRole referenceRFC822NameRole,
++         /*optional*/ const NameConstraintsSubtrees* subtreesType,
+          Input referenceRFC822Name, /*out*/ bool& matches);
+ 
+ } // namespace
+@@ -212,7 +224,7 @@ MatchPresentedDNSIDWithReferenceDNSID(Input presentedDNSID,
+   return MatchPresentedDNSIDWithReferenceDNSID(
+            presentedDNSID, AllowWildcards::Yes,
+            AllowDotlessSubdomainMatches::Yes, IDRole::ReferenceID,
+-           referenceDNSID, matches);
++           nullptr, referenceDNSID, matches);
+ }
+ 
+ // Verify that the given end-entity cert, which is assumed to have been already
+@@ -731,7 +743,7 @@ MatchPresentedIDWithReferenceID(GeneralNameType presentedIDType,
+       rv = MatchPresentedDNSIDWithReferenceDNSID(
+              presentedID, AllowWildcards::Yes,
+              AllowDotlessSubdomainMatches::Yes, IDRole::ReferenceID,
+-             referenceID, foundMatch);
++             nullptr, referenceID, foundMatch);
+       break;
+ 
+     case GeneralNameType::iPAddress:
+@@ -741,7 +753,7 @@ MatchPresentedIDWithReferenceID(GeneralNameType presentedIDType,
+ 
+     case GeneralNameType::rfc822Name:
+       rv = MatchPresentedRFC822NameWithReferenceRFC822Name(
+-             presentedID, IDRole::ReferenceID, referenceID, foundMatch);
++             presentedID, IDRole::ReferenceID, nullptr, referenceID, foundMatch);
+       break;
+ 
+     case GeneralNameType::directoryName:
+@@ -767,20 +779,16 @@ MatchPresentedIDWithReferenceID(GeneralNameType presentedIDType,
+   return Success;
+ }
+ 
+-enum class NameConstraintsSubtrees : uint8_t
+-{
+-  permittedSubtrees = der::CONSTRUCTED | der::CONTEXT_SPECIFIC | 0,
+-  excludedSubtrees  = der::CONSTRUCTED | der::CONTEXT_SPECIFIC | 1
+-};
+-
+ Result CheckPresentedIDConformsToNameConstraintsSubtrees(
+          GeneralNameType presentedIDType,
+          Input presentedID,
+          Reader& nameConstraints,
+          NameConstraintsSubtrees subtreesType);
++
+ Result MatchPresentedIPAddressWithConstraint(Input presentedID,
+                                              Input iPAddressConstraint,
+                                              /*out*/ bool& foundMatch);
++
+ Result MatchPresentedDirectoryNameWithConstraint(
+          NameConstraintsSubtrees subtreesType, Input presentedID,
+          Input directoryNameConstraint, /*out*/ bool& matches);
+@@ -886,7 +894,7 @@ CheckPresentedIDConformsToNameConstraintsSubtrees(
+           rv = MatchPresentedDNSIDWithReferenceDNSID(
+                  presentedID, AllowWildcards::Yes,
+                  AllowDotlessSubdomainMatches::Yes, IDRole::NameConstraint,
+-                 base, matches);
++                 &subtreesType, base, matches);
+           if (rv != Success) {
+             return rv;
+           }
+@@ -911,7 +919,7 @@ CheckPresentedIDConformsToNameConstraintsSubtrees(
+ 
+         case GeneralNameType::rfc822Name:
+           rv = MatchPresentedRFC822NameWithReferenceRFC822Name(
+-                 presentedID, IDRole::NameConstraint, base, matches);
++                 presentedID, IDRole::NameConstraint, &subtreesType, base, matches);
+           if (rv != Success) {
+             return rv;
+           }
+@@ -1094,6 +1102,7 @@ MatchPresentedDNSIDWithReferenceDNSID(
+   AllowWildcards allowWildcards,
+   AllowDotlessSubdomainMatches allowDotlessSubdomainMatches,
+   IDRole referenceDNSIDRole,
++  /*optional*/ const NameConstraintsSubtrees* subtreesType,
+   Input referenceDNSID,
+   /*out*/ bool& matches)
+ {
+@@ -1184,18 +1193,28 @@ MatchPresentedDNSIDWithReferenceDNSID(
+       return NotReached("Skipping '*' failed",
+                         Result::FATAL_ERROR_LIBRARY_FAILURE);
+     }
+-    do {
+-      // This will happen if reference is a single, relative label
+-      if (reference.AtEnd()) {
+-        matches = false;
+-        return Success;
+-      }
+-      uint8_t referenceByte;
+-      if (reference.Read(referenceByte) != Success) {
+-        return NotReached("invalid reference ID",
+-                          Result::FATAL_ERROR_INVALID_ARGS);
+-      }
+-    } while (!reference.Peek('.'));
++    // For the permittedSubtrees of a name constraint, wildcard presented
++    // DNSIDs of the form `*.example.com` only match if the name constraint is
++    // of the form `.example.com` or `example.com`. To put it another way, a
++    // permittedSubtrees of `foo.example.com` does not match a wildcard
++    // presented DNSID of `*.example.com`, because in that case, the
++    // certificate could be valid for `bar.example.com`, which does not match
++    // the name constraint.
++    if (referenceDNSIDRole != IDRole::NameConstraint ||
++        (subtreesType && *subtreesType != NameConstraintsSubtrees::permittedSubtrees)) {
++      do {
++        // This will happen if reference is a single, relative label
++        if (reference.AtEnd()) {
++          matches = false;
++          return Success;
++        }
++        uint8_t referenceByte;
++        if (reference.Read(referenceByte) != Success) {
++          return NotReached("invalid reference ID",
++                            Result::FATAL_ERROR_INVALID_ARGS);
++        }
++      } while (!reference.Peek('.'));
++    }
+   }
+ 
+   for (;;) {
+@@ -1552,11 +1571,13 @@ IsValidRFC822Name(Input input)
+   }
+ }
+ 
++// `subtreesType` is relevant only when `referenceRFC822NameRole` is
++// `IDRole::NameConstraint`.
+ Result
+-MatchPresentedRFC822NameWithReferenceRFC822Name(Input presentedRFC822Name,
+-                                                IDRole referenceRFC822NameRole,
+-                                                Input referenceRFC822Name,
+-                                                /*out*/ bool& matches)
++MatchPresentedRFC822NameWithReferenceRFC822Name(
++  Input presentedRFC822Name, IDRole referenceRFC822NameRole,
++  /*optional*/ const NameConstraintsSubtrees* subtreesType,
++  Input referenceRFC822Name, /*out*/ bool& matches)
+ {
+   if (!IsValidRFC822Name(presentedRFC822Name)) {
+     return Result::ERROR_BAD_DER;
+@@ -1599,6 +1620,7 @@ MatchPresentedRFC822NameWithReferenceRFC822Name(Input presentedRFC822Name,
+       return MatchPresentedDNSIDWithReferenceDNSID(
+                presentedDNSID, AllowWildcards::No,
+                AllowDotlessSubdomainMatches::No, IDRole::NameConstraint,
++               subtreesType,
+                referenceRFC822Name, matches);
+     }
+   }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 38_hurd.patch
 80_security_tools.patch
 CVE-2026-2781.patch
+CVE-2026-6766-6767.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,5 @@
 38_hurd.patch
 80_security_tools.patch
 CVE-2026-2781.patch
-CVE-2026-6766-6767.patch
+CVE-2026-6766.patch
+CVE-2026-6767.patch


### PR DESCRIPTION
## CVE-2026-6766, CVE-2026-6767

**CVE-2026-6766** (Bug 2023207): Integer underflow in tls13_AEAD when ciphertext is shorter than tag.
- Upstream fix: https://hg.mozilla.org/projects/nss/rev/b009fc00297d
- Backported as `debian/patches/CVE-2026-6766.patch`

**CVE-2026-6767** (Bug 2023209): permittedSubtrees wildcard matching bypass in NSS mozpkix library.
- Upstream fix: https://hg.mozilla.org/projects/nss/rev/c25593a09fd4
- Backported as `debian/patches/CVE-2026-6767.patch`

Both vulnerabilities were fixed in Firefox ESR 140.10 (MFSA-2026-32).

CVE-2026-2959: no public information available.

Fix-Approach: upstream-backport
Generated-By: deepseek-v4-flash
Co-Authored-By: hudeng <hudeng@deepin.org>